### PR TITLE
Specify Python2.7 in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ CLASSIFIERS= [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 2.7",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Software Development :: Libraries :: Python Modules",
     ]


### PR DESCRIPTION
Hello! I tried to install eggnog-mapper in an environment with Python3 and the install proceeded successfully, but then I got syntax errors showing that the project was actually only for Python2.7. This PR adds the Python 2.7 classification to the setup.py to prevent installation on Python 3 setups.

```
(eggnog-mapper) 
 Wed 26 Sep - 09:58  ~/code/eggnog-mapper   origin ☊ master ✔ 
  ./download_eggnog_data.py 
  File "./download_eggnog_data.py", line 10
    print colorify(cmd, 'cyan')
                 ^
SyntaxError: invalid syntax
```