### PR TITLE
python2 shebang

### DIFF
--- a/download_eggnog_data.py
+++ b/download_eggnog_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 from argparse import ArgumentParser
 from eggnogmapper.common import EGGNOG_DATABASES, get_data_path, get_hmmdb_path, pexists, pjoin, get_level_base_path, set_data_path, existing_dir, get_db_present, get_db_info

--- a/eggnogmapper/search.py
+++ b/eggnogmapper/search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from __future__ import absolute_import
 
 import sys

--- a/emapper.py
+++ b/emapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 import errno

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2
 import os
 from setuptools import setup, find_packages
     


### PR DESCRIPTION
This changes shebangs to `python2` for [PEP394](https://www.python.org/dev/peps/pep-0394/) compliance. Since Python2 is now officially EOL, `python` will point to python3 in many (most?) configurations.