### PR TITLE
Add possibility to configure DATA_DIR via an environment variable

### DIFF
--- a/download_eggnog_data.py
+++ b/download_eggnog_data.py
@@ -79,6 +79,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    if "EGGNOG_DATA_DIR" in os.environ:
+        set_data_path(os.environ["EGGNOG_DATA_DIR"])
+
     if args.data_dir:
         set_data_path(args.data_dir)
 

--- a/emapper.py
+++ b/emapper.py
@@ -949,6 +949,9 @@ def parse_args(parser):
         print get_version()
         sys.exit(0)
 
+    if "EGGNOG_DATA_DIR" in os.environ:
+        set_data_path(os.environ["EGGNOG_DATA_DIR"])
+
     if args.data_dir:
         set_data_path(args.data_dir)
 


### PR DESCRIPTION
I added a way to specify the DATA_DIR via the `EGGNOG_DATA_DIR` environment variable. I needed this to avoid patching other tools that use eggnog-mapper without exposing an option to change the data_dir. 

Usage:
```
export EGGNOG_DATA_DIR="/somewhere/my_databases"
download_eggnog_data.py
emapper.py [...]
```

Hope that it helps others and that it is a feature you might want to include.