### PR TITLE
add --dbname option to download_eggnog_data.py

### DIFF
--- a/download_eggnog_data.py
+++ b/download_eggnog_data.py
@@ -211,6 +211,12 @@ if __name__ == "__main__":
                             f'Available tax IDs can be found at {EGGNOG_DOWNLOADS_URL}.'
                         ))
     
+    parser.add_argument('--dbname', type=str, dest="dbname",
+                        help=(
+                            'Tax ID of eggNOG HMM database to download. '
+                            f'e.g. "-H -d 2 --dbname \'Bacteria\'" to download Bacteria (taxid 2) to a directory named Bacteria'
+                        ))
+
     parser.add_argument('-y', action="store_true", dest='allyes',
                         help='assume "yes" to all questions')
 
@@ -316,7 +322,12 @@ if __name__ == "__main__":
     if args.hmmer == True:
         if args.allyes or ask(f"Download HMMER database of tax ID {args.hmmer_dbs}?") == 'y':
             
-            dbname = args.hmmer_dbs if args.allyes == True else ask_name('Please, specify a non-empty name for the database (e.g. Bacteria)', args.hmmer_dbs)
+            if args.dbname:
+                dbname = args.dbname
+            elif args.allyes == True:
+                dbname = args.hmmer_dbs
+            else:
+                dbname = ask_name('Please, specify a non-empty name for the database (e.g. Bacteria)', args.hmmer_dbs)
 
             dbspath = get_hmmer_base_dbpath(dbname)
             if args.force or not pexists(dbspath):                    


### PR DESCRIPTION
Add option and logic to download_eggnot_data.py to allow specifying the local directory name for the HMMER database being downloaded.

Currently, the user can specify the local name in response to an interactive prompt; with the -y option, the name is set to be the taxid. There is no other possibility.

This adds the --dbname STR option, which (like the -d option) is only used when -H is specified. If this option is specified with a nonempty value, it will be used for the value of dbname; otherwise the behaviour is the same as the current behaviour. 